### PR TITLE
fix(web): honor full-URL VITE_API_BASE in cross-origin fetches

### DIFF
--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -19,17 +19,20 @@ export interface ApiRequest {
 }
 
 function buildUrl(path: string, query?: ApiRequest["query"]): string {
-  const url = new URL(
-    `${apiBase}${path.startsWith("/") ? path : `/${path}`}`,
-    window.location.origin,
-  );
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  // apiBase may be a full URL (cross-origin API, e.g. prod) or a path (dev
+  // proxy, e.g. "/api"). Resolve against window.location.origin so a path-only
+  // base stays same-origin; a full URL keeps its own host.
+  const url = new URL(`${apiBase}${normalizedPath}`, window.location.origin);
   if (query) {
     for (const [key, value] of Object.entries(query)) {
       if (value === undefined || value === null || value === "") continue;
       url.searchParams.set(key, String(value));
     }
   }
-  return url.pathname + url.search;
+  // When apiBase is same-origin we could return a relative path, but returning
+  // the absolute href works in both cases and preserves a cross-origin host.
+  return url.href;
 }
 
 export async function apiFetch<T>(req: ApiRequest): Promise<T> {


### PR DESCRIPTION
## Problem

In production the web app called `https://miel.gousse.cool/accounts` (its own origin) instead of `https://miel-api.gousse.cool/accounts`, ignoring `VITE_API_BASE`.

## Root cause

`buildUrl` in `packages/web/src/api/client.ts` returned `url.pathname + url.search`, discarding the host. With a full-URL base (prod), the fetch flattened to a same-origin path. It worked locally only because the dev base is a path (`/api`) served by the Vite proxy.

## Fix

Return `url.href` so a full-URL base keeps its host while a path-only base still resolves same-origin. Mirrors the logic already used correctly in `buildSyncWsUrl`.

## Deploy notes

- Web is build-time baked — redeploy the web service after merge.
- Ensure the API service has `WEB_ORIGIN=https://miel.gousse.cool` so CORS allows the cross-origin calls.