### PR TITLE
fix(web): strip /api prefix with explicit rewrite in nginx proxy

### DIFF
--- a/packages/web/nginx.conf.template
+++ b/packages/web/nginx.conf.template
@@ -17,7 +17,11 @@ server {
   # both /sync/ws and /api/sync/ws, so the stripped /sync/ws works too.
   location /api/ {
     set $api_upstream ${API_UPSTREAM};
-    proxy_pass http://$api_upstream/;
+    # Strip the /api prefix explicitly. A variable in proxy_pass disables
+    # nginx's automatic location-based URI rewrite (the trailing-slash trick),
+    # so without this rewrite the API would receive /api/accounts and 404.
+    rewrite ^/api/(.*)$ /$1 break;
+    proxy_pass http://$api_upstream;
 
     proxy_http_version 1.1;
     proxy_set_header Host $host;


### PR DESCRIPTION
## Problem

After wiring `API_UPSTREAM` to the real API container name, the 502 was gone but `/api/accounts` returned `404 {"error":"not_found"}` and `/api/health` returned `401`.

Root cause: a **variable** in `proxy_pass` (`http://$api_upstream`) disables nginx's automatic location-based URI rewrite (the trailing-slash trick). So `proxy_pass http://$api_upstream/` did **not** strip `/api` — the API received `/api/accounts` (no route → 404) and `/api/health` (no route → fell through to bearer auth → 401).

## Fix

Add `rewrite ^/api/(.*)$ /$1 break;` and use a bare `proxy_pass http://$api_upstream;`. Now `/api/accounts` → `/accounts` and `/api/sync/ws` → `/sync/ws` reach the API.

Validated with `nginx -t` in the real nginx:1.27-alpine image. Web autoDeploys on merge (watchPaths cover `packages/web/**`).