### PR TITLE
feat(auth): detect and drive Claude CLI login from the web UI

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1,9 +1,19 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { createGogAdapter } from "@miel/core";
+import {
+  createGogAdapter,
+  getClaudeAuthStatus,
+  startClaudeLoginSession,
+  submitClaudeLoginCode,
+} from "@miel/core";
 
 const ReauthBody = z.object({
   account: z.string().email(),
+});
+
+const ClaudeLoginCodeBody = z.object({
+  sessionId: z.string().min(1),
+  code: z.string().min(1),
 });
 
 export const authRoutes = new Hono();
@@ -19,4 +29,35 @@ authRoutes.post("/reauth", async (c) => {
     /* surfaced via subsequent sync attempts */
   });
   return c.json({ url: session.url });
+});
+
+// Read-only login status of the Claude CLI. ShellError -> 502 via middleware.
+authRoutes.get("/claude/status", async (c) => {
+  const status = await getClaudeAuthStatus();
+  return c.json(status);
+});
+
+// Start a Claude CLI login: spawns `claude auth login` and returns the OAuth
+// URL once it appears (awaited, like /reauth). The live process is held in core
+// keyed by sessionId until the code is submitted.
+authRoutes.post("/claude/login", async (c) => {
+  const session = await startClaudeLoginSession();
+  session.done.catch(() => {
+    /* surfaced via the /code result or a subsequent status poll */
+  });
+  return c.json({ sessionId: session.sessionId, url: session.url });
+});
+
+// Submit the pasted code to the waiting login process and await success/failure.
+authRoutes.post("/claude/login/code", async (c) => {
+  const raw = await c.req.json().catch(() => ({}));
+  const { sessionId, code } = ClaudeLoginCodeBody.parse(raw);
+  const result = await submitClaudeLoginCode(sessionId, code);
+  if (!result.ok) {
+    return c.json(
+      { error: "claude_login_failed", reason: result.error },
+      result.error === "session_not_found" ? 410 : 400,
+    );
+  }
+  return c.json({ ok: true });
 });

--- a/packages/core/src/adapters/claudeAuth.ts
+++ b/packages/core/src/adapters/claudeAuth.ts
@@ -1,0 +1,191 @@
+import type { Subprocess } from "bun";
+import { getEnv } from "../env";
+import {
+  ClaudeAuthStatus,
+  type ClaudeAuthStatusT,
+} from "../schemas/claudeAuth";
+import { createDebug } from "../util/debug";
+import { spawnJson } from "./shell";
+
+const debug = createDebug("adapter:claudeAuth");
+
+export interface ClaudeLoginSession {
+  sessionId: string;
+  url: string;
+  done: Promise<{ ok: true } | { ok: false; error: string }>;
+}
+
+type LoginProc = Subprocess<"pipe", "pipe", "pipe">;
+
+interface RegistryEntry {
+  sessionId: string;
+  proc: LoginProc;
+  url: string;
+  done: Promise<{ ok: true } | { ok: false; error: string }>;
+  createdAt: number;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+// The CLI prints the OAuth URL like:
+//   If the browser didn't open, visit: https://claude.com/cai/oauth/authorize?...
+// We also tolerate console.anthropic.com defensively.
+const CLAUDE_AUTH_URL_RE =
+  /https:\/\/(?:claude\.com\/cai\/oauth|console\.anthropic\.com)\/[^\s]+/;
+
+// Generous: the user must open the browser, sign in, and paste the code.
+const SESSION_TTL_MS = 5 * 60_000;
+const URL_TIMEOUT_MS = 15_000;
+
+// Single API instance (Bun.serve) -> module-level state is safe and shared
+// across requests. A login spans two requests (start -> code), so we keep the
+// live process here keyed by sessionId.
+const registry = new Map<string, RegistryEntry>();
+
+function cleanup(sessionId: string): void {
+  const entry = registry.get(sessionId);
+  if (!entry) return;
+  clearTimeout(entry.timer);
+  registry.delete(sessionId);
+}
+
+export async function getClaudeAuthStatus(): Promise<ClaudeAuthStatusT> {
+  const { CLAUDE_BIN } = getEnv();
+  // `claude auth status --json` exits 0 whether or not we're logged in.
+  const raw = await spawnJson({ cmd: [CLAUDE_BIN, "auth", "status", "--json"] });
+  return ClaudeAuthStatus.parse(raw);
+}
+
+async function* lines(stream: ReadableStream<Uint8Array> | null) {
+  if (!stream) return;
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    yield decoder.decode(value, { stream: true });
+  }
+}
+
+export async function startClaudeLoginSession(): Promise<ClaudeLoginSession> {
+  // Single-flight: a fresh start supersedes any in-flight attempt.
+  for (const entry of registry.values()) {
+    try {
+      entry.proc.kill();
+    } catch {}
+    cleanup(entry.sessionId);
+  }
+
+  const { CLAUDE_BIN } = getEnv();
+  const proc = Bun.spawn({
+    cmd: [CLAUDE_BIN, "auth", "login", "--claudeai"],
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "pipe", // kept open so we can write the pasted code later
+    env: { ...process.env },
+  }) as LoginProc;
+
+  let buffer = "";
+
+  const url = await new Promise<string>((resolve, reject) => {
+    let settled = false;
+    const fail = (msg: string) => {
+      if (settled) return;
+      settled = true;
+      try {
+        proc.kill();
+      } catch {}
+      reject(new Error(msg));
+    };
+    const ok = (u: string) => {
+      if (settled) return;
+      settled = true;
+      resolve(u);
+    };
+
+    (async () => {
+      try {
+        for await (const chunk of lines(proc.stdout)) {
+          buffer += chunk;
+          const m = CLAUDE_AUTH_URL_RE.exec(buffer);
+          if (m) return ok(m[0]);
+        }
+      } catch (err) {
+        fail(`stdout error: ${(err as Error).message}`);
+      }
+    })();
+
+    (async () => {
+      try {
+        for await (const chunk of lines(proc.stderr)) {
+          buffer += chunk;
+          const m = CLAUDE_AUTH_URL_RE.exec(buffer);
+          if (m) return ok(m[0]);
+        }
+      } catch (err) {
+        fail(`stderr error: ${(err as Error).message}`);
+      }
+    })();
+
+    proc.exited.then((code) => {
+      if (!settled) fail(`claude auth login exited (${code}) before printing URL`);
+    });
+
+    setTimeout(() => fail("timed out waiting for claude auth URL"), URL_TIMEOUT_MS);
+  });
+
+  const sessionId = crypto.randomUUID();
+  const done = proc.exited.then((code) =>
+    code === 0
+      ? ({ ok: true } as const)
+      : ({ ok: false as const, error: `claude auth login exit ${code}` }),
+  );
+  // Evict whenever the process finishes, however it finishes.
+  done.finally(() => cleanup(sessionId));
+
+  const timer = setTimeout(() => {
+    try {
+      proc.kill();
+    } catch {}
+    cleanup(sessionId);
+  }, SESSION_TTL_MS);
+
+  registry.set(sessionId, {
+    sessionId,
+    proc,
+    url,
+    done,
+    createdAt: Date.now(),
+    timer,
+  });
+
+  debug("login url ready", { sessionId });
+  return { sessionId, url, done };
+}
+
+export async function submitClaudeLoginCode(
+  sessionId: string,
+  code: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const entry = registry.get(sessionId);
+  if (!entry) {
+    // expired, already completed, or unknown id
+    return { ok: false, error: "session_not_found" };
+  }
+  const stdin = entry.proc.stdin;
+  if (!stdin) {
+    cleanup(sessionId);
+    return { ok: false, error: "session_stdin_unavailable" };
+  }
+  try {
+    stdin.write(new TextEncoder().encode(code.trim() + "\n"));
+    await stdin.flush();
+    // Close stdin so the CLI proceeds past the prompt and exits.
+    await stdin.end();
+  } catch (err) {
+    return { ok: false, error: `write_failed: ${(err as Error).message}` };
+  }
+  // Await success/failure synchronously; cleanup is wired via done.finally.
+  const result = await entry.done;
+  debug("login code submitted", { sessionId, ok: result.ok });
+  return result;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,13 @@ export type {
 export { createClaudeAdapter } from "./adapters/claude";
 export type { ClaudeAdapter, ClaudeRunResult } from "./adapters/claude";
 export {
+  getClaudeAuthStatus,
+  startClaudeLoginSession,
+  submitClaudeLoginCode,
+} from "./adapters/claudeAuth";
+export type { ClaudeLoginSession } from "./adapters/claudeAuth";
+export * as claudeAuthSchemas from "./schemas/claudeAuth";
+export {
   SETTING_KEYS,
   SETTING_DEFAULTS,
   getSetting,

--- a/packages/core/src/schemas/claudeAuth.ts
+++ b/packages/core/src/schemas/claudeAuth.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const ClaudeAuthStatus = z
+  .object({
+    loggedIn: z.boolean(),
+    authMethod: z.string().optional(),
+    email: z.string().optional(),
+  })
+  .passthrough();
+export type ClaudeAuthStatusT = z.infer<typeof ClaudeAuthStatus>;
+
+export const ClaudeLoginCodeRequest = z.object({
+  sessionId: z.string().min(1),
+  code: z.string().min(1),
+});
+export type ClaudeLoginCodeRequestT = z.infer<typeof ClaudeLoginCodeRequest>;

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -7,6 +7,7 @@ import type {
   ListMessagesResponse,
   ListedMessage,
   ModelSettings,
+  StartClaudeLoginResult,
 } from "./types";
 
 export interface MessageActionResult {
@@ -524,6 +525,36 @@ export function useCreateLabel() {
       }),
     onSuccess: (_data, input) => {
       qc.invalidateQueries({ queryKey: queryKeys.labels(input.accountId) });
+    },
+  });
+}
+
+export function useStartClaudeLogin() {
+  return useMutation({
+    mutationFn: async () =>
+      apiFetch<StartClaudeLoginResult>({
+        path: "/auth/claude/login",
+        method: "POST",
+      }),
+  });
+}
+
+export interface SubmitClaudeLoginCodeInput {
+  sessionId: string;
+  code: string;
+}
+
+export function useSubmitClaudeLoginCode() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: SubmitClaudeLoginCodeInput) =>
+      apiFetch<{ ok: true }>({
+        path: "/auth/claude/login/code",
+        method: "POST",
+        body: input,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.claudeAuth });
     },
   });
 }

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { apiFetch } from "./client";
 import type {
   Account,
+  ClaudeAuthStatus,
   FiltersResponse,
   Label,
   ListMessagesResponse,
@@ -20,6 +21,7 @@ export const queryKeys = {
   settings: ["settings"] as const,
   filters: (accountId: string | undefined) =>
     ["filters", accountId ?? "_all"] as const,
+  claudeAuth: ["claudeAuth"] as const,
 };
 
 export function useAccounts() {
@@ -104,5 +106,13 @@ export function useFilters(accountId: string | undefined) {
         path: "/filters",
         query: { accountId: accountId ?? undefined },
       }),
+  });
+}
+
+export function useClaudeAuthStatus() {
+  return useQuery({
+    queryKey: queryKeys.claudeAuth,
+    queryFn: async () =>
+      apiFetch<ClaudeAuthStatus>({ path: "/auth/claude/status" }),
   });
 }

--- a/packages/web/src/api/types.ts
+++ b/packages/web/src/api/types.ts
@@ -162,3 +162,14 @@ export interface ModelSettings {
   replyModel: string;
   filterModel: string;
 }
+
+export interface ClaudeAuthStatus {
+  loggedIn: boolean;
+  authMethod?: string;
+  email?: string;
+}
+
+export interface StartClaudeLoginResult {
+  sessionId: string;
+  url: string;
+}

--- a/packages/web/src/features/auth/ClaudeLoginToast.tsx
+++ b/packages/web/src/features/auth/ClaudeLoginToast.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { apiFetch, ApiError } from "../../api/client";
+import { Button } from "../../components/Button";
+import { Spinner } from "../../components/Spinner";
+
+interface Props {
+  toastId: string | number;
+  sessionId: string;
+  url: string;
+  onSuccess?: () => void;
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return "Login failed";
+}
+
+/**
+ * Rendered inside a persistent sonner toast (via toast.custom). Holds the code
+ * input locally and submits it to the waiting `claude auth login` process.
+ */
+export const ClaudeLoginToast = ({ toastId, sessionId, url, onSuccess }: Props) => {
+  const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    const trimmed = code.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await apiFetch<{ ok: true }>({
+        path: "/auth/claude/login/code",
+        method: "POST",
+        body: { sessionId, code: trimmed },
+      });
+      toast.dismiss(toastId);
+      toast.success("Claude CLI is now logged in.");
+      onSuccess?.();
+    } catch (e) {
+      setError(describeError(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex w-[340px] flex-col gap-2 rounded-md border border-miel-line bg-miel-panel p-3 text-sm">
+      <span className="font-semibold text-miel-ink">Connect Claude CLI</span>
+      <p className="text-xs text-miel-muted">
+        Open the sign-in page, complete it, then paste the code shown back here.
+      </p>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-miel-ink underline"
+      >
+        Open sign-in page
+      </a>
+      <div className="flex items-center gap-2">
+        <input
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+          }}
+          placeholder="Paste code"
+          autoFocus
+          className="flex-1 rounded border border-miel-line bg-miel-bg px-2 py-1 text-sm text-miel-ink placeholder:text-miel-muted"
+        />
+        <Button variant="primary" disabled={submitting} onClick={submit}>
+          {submitting ? <Spinner size={12} /> : null}
+          {submitting ? "Verifying…" : "Submit"}
+        </Button>
+      </div>
+      {error ? <span className="text-xs text-miel-high">{error}</span> : null}
+    </div>
+  );
+};

--- a/packages/web/src/features/auth/startClaudeLoginFlow.tsx
+++ b/packages/web/src/features/auth/startClaudeLoginFlow.tsx
@@ -1,0 +1,41 @@
+import { toast } from "sonner";
+import { apiFetch } from "../../api/client";
+import type { StartClaudeLoginResult } from "../../api/types";
+import { ClaudeLoginToast } from "./ClaudeLoginToast";
+
+/**
+ * Imperative entry point: starts a Claude CLI login session, opens the OAuth URL
+ * in a new tab, and shows a persistent toast with an input for the pasted code.
+ * Mirrors the gog reauth flow in reauthToast.tsx but adds the code paste-back.
+ */
+export async function startClaudeLoginFlow(onSuccess?: () => void): Promise<void> {
+  const pending = toast.loading("Starting Claude sign-in…", {
+    id: "claude-login-start",
+  });
+  try {
+    const res = await apiFetch<StartClaudeLoginResult>({
+      path: "/auth/claude/login",
+      method: "POST",
+    });
+    toast.dismiss(pending);
+    window.open(res.url, "_blank", "noopener,noreferrer");
+    toast.custom(
+      (id) => (
+        <ClaudeLoginToast
+          toastId={id}
+          sessionId={res.sessionId}
+          url={res.url}
+          onSuccess={onSuccess}
+        />
+      ),
+      { id: "claude-login", duration: Infinity },
+    );
+  } catch (e) {
+    toast.dismiss(pending);
+    toast.error(
+      `Could not start Claude sign-in: ${
+        e instanceof Error ? e.message : "unknown error"
+      }`,
+    );
+  }
+}

--- a/packages/web/src/features/settings/ClaudeAuthManager.tsx
+++ b/packages/web/src/features/settings/ClaudeAuthManager.tsx
@@ -1,0 +1,69 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "../../components/Button";
+import { Spinner } from "../../components/Spinner";
+import { queryKeys, useClaudeAuthStatus } from "../../api/queries";
+import { ApiError } from "../../api/client";
+import { startClaudeLoginFlow } from "../auth/startClaudeLoginFlow";
+
+function describeError(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return "Unknown error";
+}
+
+export const ClaudeAuthManager = () => {
+  const status = useClaudeAuthStatus();
+  const qc = useQueryClient();
+  const loggedIn = status.data?.loggedIn === true;
+
+  const connect = () =>
+    startClaudeLoginFlow(() =>
+      qc.invalidateQueries({ queryKey: queryKeys.claudeAuth }),
+    );
+
+  return (
+    <div className="rounded border border-miel-line bg-miel-panel p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-sm font-semibold text-miel-ink">Claude CLI</h3>
+          <p className="text-xs text-miel-muted">
+            {status.isLoading ? (
+              "Checking sign-in status…"
+            ) : status.error ? (
+              <>Could not check status: {describeError(status.error)}</>
+            ) : loggedIn ? (
+              <>
+                Logged in
+                {status.data?.email ? ` as ${status.data.email}` : ""}. Triage and
+                replies use this login.
+              </>
+            ) : (
+              "Not logged in. Triage and replies require a Claude login."
+            )}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {status.isLoading ? (
+            <Spinner size={14} />
+          ) : (
+            <span
+              className={`rounded-full px-2 py-0.5 text-xs ${
+                loggedIn
+                  ? "bg-miel-line text-miel-ink"
+                  : "bg-miel-high text-white"
+              }`}
+            >
+              {loggedIn ? "Connected" : "Disconnected"}
+            </span>
+          )}
+          <Button
+            variant={loggedIn ? "secondary" : "primary"}
+            onClick={connect}
+          >
+            {loggedIn ? "Reconnect" : "Connect Claude"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/web/src/pages/SettingsPage.tsx
+++ b/packages/web/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "../components/Spinner";
 import { EmptyState } from "../components/EmptyState";
 import { ApiError } from "../api/client";
 import { ModelPicker } from "../features/settings/ModelPicker";
+import { ClaudeAuthManager } from "../features/settings/ClaudeAuthManager";
 import { AccountsManager } from "../features/settings/AccountsManager";
 import { LabelsManager } from "../features/settings/LabelsManager";
 import { SettingsSyncTrigger } from "../features/settings/SettingsSyncTrigger";
@@ -65,6 +66,13 @@ export const SettingsPage = () => {
             />
           </div>
         ) : null}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-miel-muted">
+          Claude login
+        </h2>
+        <ClaudeAuthManager />
       </section>
 
       <section className="flex flex-col gap-3">


### PR DESCRIPTION
Detects a logged-out `claude` CLI and drives a guided login from the web UI.

Uses the scriptable `claude auth login --claudeai` (no TTY/tmux): prints the OAuth URL on stdout, reads the pasted code on stdin — mirroring the existing gog reauth adapter, with stdin kept open for the code paste-back.

- **core**: `getClaudeAuthStatus` (`claude auth status --json`), `startClaudeLoginSession` (single-flight, URL/TTL timeouts), `submitClaudeLoginCode`, backed by a module-level session registry bridging the two-request start→code flow.
- **api**: `GET /auth/claude/status`, `POST /auth/claude/login`, `POST /auth/claude/login/code` (reuses existing Zod→400 / ShellError→502).
- **web**: status query + login mutations, a persistent sonner toast with an inline code input, and a Claude-login status card on Settings.

Verified: typecheck passes (5/5 packages); status/start/single-flight/negative-code endpoints smoke-tested; existing login left intact.