### PR TITLE
feat(core): log stderr and command details on shell failures

### DIFF
--- a/packages/core/src/adapters/shell.ts
+++ b/packages/core/src/adapters/shell.ts
@@ -35,6 +35,11 @@ export function isInvalidGrantStderr(stderr: string): boolean {
   return /invalid_grant/i.test(stderr);
 }
 
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max)}… (+${s.length - max} more)`;
+}
+
 async function readAll(stream: ReadableStream<Uint8Array> | null): Promise<string> {
   if (!stream) return "";
   const reader = stream.getReader();
@@ -84,6 +89,12 @@ export async function spawnCapture(opts: SpawnJsonOptions): Promise<{
     ms: Date.now() - startedAt,
     stdoutBytes: stdout.length,
     stderrBytes: stderr.length,
+    ...(exitCode !== 0
+      ? {
+          stderr: truncate(stderr.trim(), 2000),
+          stdout: truncate(stdout.trim(), 500),
+        }
+      : {}),
   });
 
   return { stdout, stderr, exitCode };

--- a/packages/core/src/services/sync.ts
+++ b/packages/core/src/services/sync.ts
@@ -10,6 +10,7 @@ import {
   triages,
 } from "../db/schema";
 import { createGogAdapter, type GogAdapter } from "../adapters/gog";
+import { ShellError } from "../adapters/shell";
 import {
   createClaudeAdapter,
   type ClaudeAdapter,
@@ -764,7 +765,17 @@ export async function fetchAndTriage(
   return result;
   } catch (err) {
     const message = (err as Error).message ?? String(err);
-    debug("fetchAndTriage failed", { account: opts.accountEmail, error: message });
+    debug("fetchAndTriage failed", {
+      account: opts.accountEmail,
+      error: message,
+      ...(err instanceof ShellError
+        ? {
+            exitCode: err.exitCode,
+            cmd: err.cmd.join(" "),
+            stderr: err.stderr.trim() || "(empty)",
+          }
+        : {}),
+    });
     await db
       .update(syncWindows)
       .set({


### PR DESCRIPTION
## Summary
When a spawned command exits non-zero, logs now carry the actual cause instead of just byte counts and a generic "Command failed (exit N)".

- **`shell.ts`** — the `spawn done` debug line includes `stderr` (truncated to 2000 chars) and a `stdout` preview (500 chars) when `exitCode !== 0`.
- **`sync.ts`** — `fetchAndTriage failed` unpacks `ShellError` fields (`exitCode`, `cmd`, `stderr`) when the caught error is one.

## Why
A failing `gog` call previously logged `exitCode=10 stderrBytes=302` with the 302 bytes of stderr never surfaced. Now they show in both the shell and sync logs.