### PR TITLE
feat(triage): slim prompt + body-on-demand + duration in toast

### DIFF
--- a/packages/core/src/adapters/claude.test.ts
+++ b/packages/core/src/adapters/claude.test.ts
@@ -35,6 +35,7 @@ function mockSpawn(result: SpawnResult): void {
 
 const TRIAGE_INPUT: TriageInputT = {
   account: "user@example.com",
+  accountId: "acct-1",
   existingLabels: ["Work"],
   messages: [
     {

--- a/packages/core/src/adapters/claude.ts
+++ b/packages/core/src/adapters/claude.ts
@@ -51,6 +51,7 @@ interface ClaudeEnvelope {
 }
 
 function buildTriagePrompt(input: TriageInputT): string {
+  const { API_SECRET, API_PORT } = getEnv();
   return [
     "You are an email triage assistant. Classify each message and return strict JSON matching the provided schema.",
     "",
@@ -63,6 +64,18 @@ function buildTriagePrompt(input: TriageInputT): string {
     "- applyExistingLabels: zero or more names drawn EXACTLY from the existing labels list above (case-sensitive).",
     "- suggestNewLabels: propose new labels only when no existing label fits and the theme is recurring. Keep names short (<=40 chars). Reasoning is one sentence.",
     "- reasoning: one or two sentences explaining the priority choice.",
+    "",
+    "Each message gives you only sender (from), subject, snippet, and current labels.",
+    "This is enough for almost every message. ONLY when you genuinely cannot decide",
+    "priority/labels from these (ambiguous sender, empty subject, newsletter-vs-real,",
+    "etc.) may you fetch the full message body via the local API:",
+    "",
+    `  curl -s -H "Authorization: Bearer ${API_SECRET}" \\`,
+    `    http://localhost:${API_PORT}/api/messages/${input.accountId}/<id>`,
+    "",
+    "Use the message's id field as <id>. The response is JSON with bodyText/bodyHtml.",
+    "Do NOT fetch bodies you do not need — each fetch is slow and costly. If a fetch",
+    "fails, classify from sender + subject anyway; a body is never required for a result.",
     "",
     "Messages JSON:",
     JSON.stringify(input.messages),
@@ -116,6 +129,9 @@ async function invokeClaude<T>(args: {
   schema: object;
   parser: (raw: unknown) => T;
   kind: string;
+  // Tools to allow in this headless run. In `-p` mode an un-allowlisted tool
+  // call is denied (not prompted), so this must be set for the model to curl.
+  allowedTools?: string[];
 }): Promise<ClaudeRunResult<T>> {
   const { CLAUDE_BIN } = getEnv();
   const cmd = [
@@ -124,6 +140,9 @@ async function invokeClaude<T>(args: {
     "--output-format=json",
     `--model=${args.model}`,
     `--json-schema=${JSON.stringify(args.schema)}`,
+    ...(args.allowedTools && args.allowedTools.length > 0
+      ? ["--allowedTools", args.allowedTools.join(",")]
+      : []),
     args.prompt,
   ];
   debug("invoke", {
@@ -252,6 +271,9 @@ export function createClaudeAdapter(): ClaudeAdapter {
         schema: jsonSchema,
         parser: (raw) => TriageOutput.parse(raw),
         kind: "triage",
+        // Allow Bash so the model can curl the body API when it can't decide
+        // from sender + subject alone (see buildTriagePrompt escape hatch).
+        allowedTools: ["Bash"],
       });
       debug("runTriage done", {
         account: input.account,

--- a/packages/core/src/schemas/syncEvents.ts
+++ b/packages/core/src/schemas/syncEvents.ts
@@ -72,6 +72,7 @@ export const TriageFinishedEvent = z.object({
   account: z.string(),
   triaged: z.number().int().nonnegative(),
   suggestedNewLabels: z.number().int().nonnegative(),
+  elapsedMs: z.number().int().nonnegative(),
 });
 export type TriageFinishedEventT = z.infer<typeof TriageFinishedEvent>;
 

--- a/packages/core/src/schemas/triage.ts
+++ b/packages/core/src/schemas/triage.ts
@@ -6,17 +6,20 @@ export type PriorityT = z.infer<typeof Priority>;
 export const TriageInputItem = z.object({
   id: z.string(),
   from: z.string(),
-  to: z.array(z.string()),
   subject: z.string().nullable(),
   snippet: z.string().nullable(),
-  body: z.string(),
-  internalDate: z.string(),
   currentLabels: z.array(z.string()),
+  // Optional: the slim triage prompt omits these. The model fetches the body
+  // on demand via the API. Kept optional so a fuller payload still validates.
+  to: z.array(z.string()).optional(),
+  body: z.string().optional(),
+  internalDate: z.string().optional(),
 });
 export type TriageInputItemT = z.infer<typeof TriageInputItem>;
 
 export const TriageInput = z.object({
   account: z.string().email(),
+  accountId: z.string(),
   existingLabels: z.array(z.string()),
   messages: z.array(TriageInputItem).min(1).max(20),
 });

--- a/packages/core/src/services/sync.ts
+++ b/packages/core/src/services/sync.ts
@@ -325,6 +325,7 @@ async function runTriageBatches(
     emit,
   } = args;
 
+  const triageStartMs = Date.now();
   emit({
     type: "triage.started",
     account: accountEmail,
@@ -466,6 +467,7 @@ async function runTriageBatches(
     account: accountEmail,
     triaged,
     suggestedNewLabels,
+    elapsedMs: Date.now() - triageStartMs,
   });
 
   return { triaged, suggestedNewLabels, errors };
@@ -1081,6 +1083,7 @@ export async function triageUntriagedForAccount(
       account: account.email,
       triaged: 0,
       suggestedNewLabels: 0,
+      elapsedMs: 0,
     });
     return {
       account: account.email,

--- a/packages/core/src/services/sync.ts
+++ b/packages/core/src/services/sync.ts
@@ -54,7 +54,6 @@ import {
 const debug = createDebug("service:sync");
 
 const TRIAGE_BATCH_SIZE = 15;
-const BODY_TRUNCATION = 4000;
 const DEFAULT_SEARCH_MAX = 200;
 
 export interface SyncRunResult {
@@ -83,9 +82,6 @@ interface NormalizedMessage {
   labelIds: string[];
 }
 
-function truncate(s: string, n: number): string {
-  return s.length > n ? s.slice(0, n) : s;
-}
 
 function normalizeMessage(
   accountId: string,
@@ -226,14 +222,13 @@ function buildTriageItems(
   rows: NormalizedMessage[],
   labelsByGmailId: Map<string, LabelRow>,
 ): TriageInputItemT[] {
+  // Slim payload: sender + subject + snippet + current labels only. The model
+  // fetches the full body on demand (see buildTriagePrompt) when it can't decide.
   return rows.map((r) => ({
     id: r.gmailMessageId,
     from: r.fromEmail,
-    to: r.toEmails,
     subject: r.subject,
     snippet: r.snippet,
-    body: truncate(r.bodyText, BODY_TRUNCATION),
-    internalDate: r.internalDate.toISOString(),
     currentLabels: r.labelIds
       .map((id) => labelsByGmailId.get(id)?.name)
       .filter((n): n is string => Boolean(n)),
@@ -349,6 +344,7 @@ async function runTriageBatches(
     const items = buildTriageItems(batch, labelsByGmailId);
     const input = TriageInput.parse({
       account: accountEmail,
+      accountId,
       existingLabels: existingLabelNames,
       messages: items,
     });

--- a/packages/web/src/api/syncSocket.ts
+++ b/packages/web/src/api/syncSocket.ts
@@ -37,6 +37,17 @@ function triageToastId(account: string): string {
   return `sync:triage:${account}`;
 }
 
+// Human-friendly elapsed time for the triage-finished toast.
+// <1s → "0.4s", <60s → "12s", else "1m 05s".
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${(ms / 1000).toFixed(1)}s`;
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
 function filtersToastId(account: string): string {
   return `sync:filters:${account}`;
 }
@@ -95,11 +106,12 @@ function dispatchEvent(
       return;
     case "triage.finished": {
       toast.dismiss(triageToastId(event.account));
+      const elapsed = formatElapsed(event.elapsedMs);
       toast.success(`Claude finished triaging ${event.account}`, {
         description:
           event.suggestedNewLabels > 0
-            ? `${event.triaged} triaged, ${event.suggestedNewLabels} new label suggestion${event.suggestedNewLabels === 1 ? "" : "s"}`
-            : `${event.triaged} triaged`,
+            ? `${event.triaged} triaged in ${elapsed}, ${event.suggestedNewLabels} new label suggestion${event.suggestedNewLabels === 1 ? "" : "s"}`
+            : `${event.triaged} triaged in ${elapsed}`,
       });
       qc.invalidateQueries({ queryKey: ["messages"] });
       qc.invalidateQueries({ queryKey: queryKeys.accounts });


### PR DESCRIPTION
## Summary

Two related triage changes:

1. **Slim triage prompt** — stop sending the full message body to Claude for every message. The prompt now carries only `id`/`from`/`subject`/`snippet`/`currentLabels`. A curl escape hatch (real `API_SECRET`/`API_PORT`/`accountId` baked in) lets the model fetch the full body from `GET /api/messages/:accountId/:id` only when it genuinely can't decide. The headless triage run is invoked with `--allowedTools Bash` so that fetch is permitted (un-allowlisted tools are *denied*, not prompted, in `-p` mode). Faster, cheaper triage for the common case.

2. **Triage duration in toast** — add `elapsedMs` to the `triage.finished` event, measured across `runTriageBatches`. The web completion toast now reads `"N triaged in 12s"` (`formatElapsed` renders sub-second / seconds / `m:ss`).

## Changes

- `schemas/triage.ts` — `body`/`to`/`internalDate` optional; `accountId` added to `TriageInput`.
- `services/sync.ts` — `buildTriageItems` emits slim payload; removed unused `truncate`/`BODY_TRUNCATION`; timing capture + `elapsedMs` on both `triage.finished` emit sites.
- `adapters/claude.ts` — body-fetch prompt block; `invokeClaude` `allowedTools` option; `runTriage` passes `["Bash"]`.
- `schemas/syncEvents.ts` — `elapsedMs` on `TriageFinishedEvent`.
- `web/src/api/syncSocket.ts` — `formatElapsed` helper; toast shows duration.

## Notes / risks

- `--allowedTools Bash` widens the headless triage agent's surface. Acceptable: local-only, bearer-guarded API; prompt scopes usage.
- Body fetch is best-effort — on 401/failure the model still classifies from sender+subject.

## Verification

- `bun run typecheck` green across all 4 packages.
- Core `src/` tests pass (31) with Postgres up.
- Not yet run live (needs gog auth + real Claude run): CLI sync smoke.